### PR TITLE
pass string to parseReferenceObject method

### DIFF
--- a/lib/v3.1/schema/parse.js
+++ b/lib/v3.1/schema/parse.js
@@ -65,12 +65,12 @@ function parseReferenceObject (
   openapiObject,
   path,
   method,
-  referenceObject
+  reference
 ) {
-  if (typeof referenceObject[FIELD_NAME.REF] !== 'string') {
+  if (typeof reference !== 'string') {
     // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#reference-object
     // > REQUIRED. The reference identifier. This MUST be in the form of a URI.
-    throw new Error(`The reference identifier is must be in the form of a URI. ${referenceObject[FIELD_NAME]}`)
+    throw new Error(`The reference identifier is must be in the form of a URI. Current value: ${reference}`)
   }
 
   return resolveReferenceObject(
@@ -78,7 +78,7 @@ function parseReferenceObject (
     openapiObject,
     path,
     method,
-    referenceObject[FIELD_NAME.REF].split('/').slice(1),
+    reference.split('/').slice(1),
     openapiObject
   )
 }
@@ -99,7 +99,7 @@ function parseSchemaObjectProperties (
       openapiObject,
       path,
       method,
-      schemaObject
+      schemaObject[FIELD_NAME.REF]
     ).forEach(n => nodes.push(n))
   }
 
@@ -154,7 +154,7 @@ function parseSchemaObjectProperties (
               openapiObject,
               path,
               method,
-              schemaObject[FIELD_NAME.ITEMS]
+              schemaObject[FIELD_NAME.ITEMS][FIELD_NAME.REF]
             )
             : parseSchemaObjectProperties(
               inputPath,


### PR DESCRIPTION
## Changes
<!-- Describe your changes in bullet points -->
- Pass string to `parseReferenceObject` method.

## Related issue
<!-- Please link to the issue here -->
- 
