### PR TITLE
split parseReferenceObject function to a file

### DIFF
--- a/lib/v3.1/parseReferenceObject.js
+++ b/lib/v3.1/parseReferenceObject.js
@@ -1,0 +1,41 @@
+function resolveReferenceObject (
+  inputPath,
+  openapiObject,
+  paths,
+  currentObject
+) {
+  if (paths.length > 1) {
+    return resolveReferenceObject(
+      inputPath,
+      openapiObject,
+      paths,
+      currentObject[paths.shift()]
+    )
+  }
+
+  return currentObject[paths.shift()]
+}
+
+// https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#reference-object
+function parseReferenceObject (
+  inputPath,
+  openapiObject,
+  reference
+) {
+  if (typeof reference !== 'string') {
+    // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#reference-object
+    // > REQUIRED. The reference identifier. This MUST be in the form of a URI.
+    throw new Error(`The reference identifier is must be in the form of a URI. Current value: ${reference}`)
+  }
+
+  return resolveReferenceObject(
+    inputPath,
+    openapiObject,
+    reference.split('/').slice(1),
+    openapiObject
+  )
+}
+
+module.exports = {
+  parseReferenceObject
+}

--- a/lib/v3.1/schema/parse.js
+++ b/lib/v3.1/schema/parse.js
@@ -5,6 +5,9 @@ const {
   MEDIA_TYPE,
   PARAMETER_LOCATION
 } = require('../constants')
+const {
+  parseReferenceObject
+} = require('../parseReferenceObject')
 
 // https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00#section-4.2.1
 function valueToLiteral (value) {
@@ -29,44 +32,6 @@ function valueToLiteral (value) {
   }
 
   throw new Error(`unexpected default value type. [${typeof value}]`)
-}
-
-function resolveReferenceObject (
-  inputPath,
-  openapiObject,
-  paths,
-  currentObject
-) {
-  if (paths.length > 1) {
-    return resolveReferenceObject(
-      inputPath,
-      openapiObject,
-      paths,
-      currentObject[paths.shift()]
-    )
-  }
-
-  return currentObject[paths.shift()]
-}
-
-// https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#reference-object
-function parseReferenceObject (
-  inputPath,
-  openapiObject,
-  reference
-) {
-  if (typeof reference !== 'string') {
-    // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#reference-object
-    // > REQUIRED. The reference identifier. This MUST be in the form of a URI.
-    throw new Error(`The reference identifier is must be in the form of a URI. Current value: ${reference}`)
-  }
-
-  return resolveReferenceObject(
-    inputPath,
-    openapiObject,
-    reference.split('/').slice(1),
-    openapiObject
-  )
 }
 
 // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schema-object

--- a/lib/v3.1/type/parse.js
+++ b/lib/v3.1/type/parse.js
@@ -8,6 +8,9 @@ const {
   PARAMETER_LOCATION,
   PRIMITIVE_TYPE
 } = require('../constants')
+const {
+  parseReferenceObject
+} = require('../parseReferenceObject')
 
 function toOASTypeNode (type) {
   if (type === OAS_DEFINED_TYPE.INTEGER) {
@@ -106,44 +109,6 @@ function toTypeNode (
   }
 
   throw new Error(`unexpected type ${JSON.stringify(obj[FIELD_NAME.TYPE])}`)
-}
-
-function resolveReferenceObject (
-  inputPath,
-  openapiObject,
-  paths,
-  currentObject
-) {
-  if (paths.length > 1) {
-    return resolveReferenceObject(
-      inputPath,
-      openapiObject,
-      paths,
-      currentObject[paths.shift()]
-    )
-  }
-
-  return currentObject[paths.shift()]
-}
-
-// https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#reference-object
-function parseReferenceObject (
-  inputPath,
-  openapiObject,
-  reference
-) {
-  if (typeof reference !== 'string') {
-    // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#reference-object
-    // > REQUIRED. The reference identifier. This MUST be in the form of a URI.
-    throw new Error(`The reference identifier is must be in the form of a URI. Current value: ${reference}`)
-  }
-
-  return resolveReferenceObject(
-    inputPath,
-    openapiObject,
-    reference.split('/').slice(1),
-    openapiObject
-  )
 }
 
 // https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#schema-object


### PR DESCRIPTION
## Changes
<!-- Describe your changes in bullet points -->
- split `parseReferenceObject` function to a file.

## Related issue
<!-- Please link to the issue here -->
- 
